### PR TITLE
move phrase management to separate Extractor

### DIFF
--- a/Extractor.js
+++ b/Extractor.js
@@ -1,0 +1,53 @@
+/*
+ * abstraction for containing extracted phrases from react-globalize-compiler
+ */
+var extend = require("util")._extend;
+var reactGlobalizeCompiler = require("react-globalize-compiler");
+
+function Extractor() {
+  this.asts = {};
+  this.defaultMessages = {};
+  this.extracts = {};
+}
+
+Extractor.prototype.allDefaultMessages = function() {
+  return Object.keys(this.defaultMessages).reduce(function(sum, request) {
+    extend(sum, this.defaultMessages[request]);
+    return sum;
+  }, {});
+}
+
+Extractor.prototype.getDefaultMessages = function(request) {
+  if (!request) {
+    return this.allDefaultMessages();
+  }
+
+  if (!this.defaultMessages[request]) {
+    // Statically extract Globalize & React Globalize default messages.
+    this.defaultMessages[request] =
+      reactGlobalizeCompiler.extractDefaultMessages(this.asts[request]);
+  }
+
+  return this.defaultMessages[request];
+}
+
+Extractor.prototype.allExtracts = function() {
+  return Object.keys(this.extracts).map(function(request) {
+    return this.extracts[request];
+  });
+}
+
+Extractor.prototype.getExtracts = function(request) {
+  if (!request) {
+    return this.allExtracts();
+  }
+
+  if (!this.extracts[request]) {
+    // Statically extract React Globalize formatters.
+    this.extracts[request] = reactGlobalizeCompiler.extract(this.asts[request]);
+  }
+
+  return this.extracts[request];
+}
+
+module.exports = Extractor;

--- a/Extractor.js
+++ b/Extractor.js
@@ -11,8 +11,9 @@ function Extractor() {
 }
 
 Extractor.prototype.allDefaultMessages = function() {
-  return Object.keys(this.defaultMessages).reduce(function(sum, request) {
-    extend(sum, this.defaultMessages[request]);
+  var defaultMessages = this.defaultMessages;
+  return Object.keys(defaultMessages).reduce(function(sum, request) {
+    extend(sum, defaultMessages[request]);
     return sum;
   }, {});
 }
@@ -32,8 +33,9 @@ Extractor.prototype.getDefaultMessages = function(request) {
 }
 
 Extractor.prototype.allExtracts = function() {
-  return Object.keys(this.extracts).map(function(request) {
-    return this.extracts[request];
+  var extracts = this.extracts;
+  return Object.keys(extracts).map(function(request) {
+    return extracts[request];
   });
 }
 

--- a/Extractor.js
+++ b/Extractor.js
@@ -16,7 +16,7 @@ Extractor.prototype.allDefaultMessages = function() {
     extend(sum, defaultMessages[request]);
     return sum;
   }, {});
-}
+};
 
 Extractor.prototype.getDefaultMessages = function(request) {
   if (!request) {
@@ -30,14 +30,14 @@ Extractor.prototype.getDefaultMessages = function(request) {
   }
 
   return this.defaultMessages[request];
-}
+};
 
 Extractor.prototype.allExtracts = function() {
   var extracts = this.extracts;
   return Object.keys(extracts).map(function(request) {
     return extracts[request];
   });
-}
+};
 
 Extractor.prototype.getExtracts = function(request) {
   if (!request) {
@@ -50,6 +50,6 @@ Extractor.prototype.getExtracts = function(request) {
   }
 
   return this.extracts[request];
-}
+};
 
 module.exports = Extractor;

--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -1,6 +1,5 @@
 var extend = require("util")._extend;
 var Extractor = require('./Extractor');
-var reactGlobalizeCompiler = require("react-globalize-compiler");
 
 function alwaysArray(stringOrArray) {
   return Array.isArray(stringOrArray) ? stringOrArray : stringOrArray ? [stringOrArray] : [];

--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -1,5 +1,5 @@
 var extend = require("util")._extend;
-var Extractor = require('./Extractor');
+var Extractor = require("./Extractor");
 
 function alwaysArray(stringOrArray) {
   return Array.isArray(stringOrArray) ? stringOrArray : stringOrArray ? [stringOrArray] : [];
@@ -43,7 +43,7 @@ function ProductionModePlugin(attributes) {
 }
 
 ProductionModePlugin.prototype.apply = function(compiler) {
-  var extractor = new Extractor;
+  var extractor = new Extractor();
 
   // Map eash AST and its request filepath.
   compiler.parser.plugin("program", function(ast) {


### PR DESCRIPTION
See my comment on #2 - this refactor encapsulates the phrase extraction and management in one object, so `ProductionModePlugin` only deals with webpack-plugin lifecycle concerns.
