### PR TITLE
auto-generate messages files

### DIFF
--- a/Extractor.js
+++ b/Extractor.js
@@ -1,0 +1,55 @@
+/*
+ * abstraction for containing extracted phrases from react-globalize-compiler
+ */
+var extend = require("util")._extend;
+var reactGlobalizeCompiler = require("react-globalize-compiler");
+
+function Extractor() {
+  this.asts = {};
+  this.defaultMessages = {};
+  this.extracts = {};
+}
+
+Extractor.prototype.allDefaultMessages = function() {
+  var defaultMessages = this.defaultMessages;
+  return Object.keys(defaultMessages).reduce(function(sum, request) {
+    extend(sum, defaultMessages[request]);
+    return sum;
+  }, {});
+};
+
+Extractor.prototype.getDefaultMessages = function(request) {
+  if (!request) {
+    return this.allDefaultMessages();
+  }
+
+  if (!this.defaultMessages[request]) {
+    // Statically extract Globalize & React Globalize default messages.
+    this.defaultMessages[request] =
+      reactGlobalizeCompiler.extractDefaultMessages(this.asts[request]);
+  }
+
+  return this.defaultMessages[request];
+};
+
+Extractor.prototype.allExtracts = function() {
+  var extracts = this.extracts;
+  return Object.keys(extracts).map(function(request) {
+    return extracts[request];
+  });
+};
+
+Extractor.prototype.getExtracts = function(request) {
+  if (!request) {
+    return this.allExtracts();
+  }
+
+  if (!this.extracts[request]) {
+    // Statically extract React Globalize formatters.
+    this.extracts[request] = reactGlobalizeCompiler.extract(this.asts[request]);
+  }
+
+  return this.extracts[request];
+};
+
+module.exports = Extractor;

--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -1,5 +1,5 @@
 var extend = require("util")._extend;
-var reactGlobalizeCompiler = require("react-globalize-compiler");
+var Extractor = require("./Extractor");
 
 function alwaysArray(stringOrArray) {
   return Array.isArray(stringOrArray) ? stringOrArray : stringOrArray ? [stringOrArray] : [];
@@ -43,52 +43,11 @@ function ProductionModePlugin(attributes) {
 }
 
 ProductionModePlugin.prototype.apply = function(compiler) {
-  var asts = {};
-  var defaultMessages = {};
-  var extracts = {};
-
-  function allDefaultMessages() {
-    return Object.keys(defaultMessages).reduce(function(sum, request) {
-      extend(sum, defaultMessages[request]);
-      return sum;
-    }, {});
-  }
-
-  function allExtracts() {
-    return Object.keys(extracts).map(function(request) {
-      return extracts[request];
-    });
-  }
-
-  function getDefaultMessages(request) {
-    if (!request) {
-      return allDefaultMessages();
-    }
-
-    if (!defaultMessages[request]) {
-      // Statically extract Globalize & React Globalize default messages.
-      defaultMessages[request] = reactGlobalizeCompiler.extractDefaultMessages(asts[request]);
-    }
-
-    return defaultMessages[request];
-  }
-
-  function getExtracts(request) {
-    if (!request) {
-      return allExtracts();
-    }
-
-    if (!extracts[request]) {
-      // Statically extract React Globalize formatters.
-      extracts[request] = reactGlobalizeCompiler.extract(asts[request]);
-    }
-
-    return extracts[request];
-  }
+  var extractor = new Extractor();
 
   // Map eash AST and its request filepath.
   compiler.parser.plugin("program", function(ast) {
-    asts[this.state.current.request] = ast;
+    extractor.asts[this.state.current.request] = ast;
   });
 
   // Sneaks in modules that `require("react-globalize")` and create custom
@@ -96,14 +55,14 @@ ProductionModePlugin.prototype.apply = function(compiler) {
   compiler.parser.plugin("call require:commonjs:item", function(expr, param) {
     var request = this.state.current.request;
     if(param.isString() && param.string === "react-globalize") {
-      getDefaultMessages(request);
-      getExtracts(request);
+      extractor.getDefaultMessages(request);
+      extractor.getExtracts(request);
     }
   });
 
   compiler.plugin("globalize-before-compile-extracts", function(locale, attributes, request) {
-    var extracts = getExtracts(request);
-    var defaultMessages = getDefaultMessages(request);
+    var extracts = extractor.getExtracts(request);
+    var defaultMessages = extractor.getDefaultMessages(request);
 
     if (extracts) {
       attributes.extracts = attributes.extracts ? arrayClone(alwaysArray(attributes.extracts)) : [];

--- a/README.md
+++ b/README.md
@@ -2,8 +2,15 @@
 
 README to be defined.
 
-For now, please read [Globalize Webpack Plugin][] documentation. Usage is pretty
-much similar. Also, see [react-globalize][] and [Globalize][].
+For now, please read [Globalize Webpack Plugin][] documentation. Usage is very
+similar, but with one more attribute:
+
+* `writeMessages`: writes new default messages for all supported locales
+  under the `messages` filepath specified.
+
+`writeMessages` requires `messages` to be set.
+
+Also, see [react-globalize][] and [Globalize][].
 
 [Globalize]: https://github.com/jquery/globalize/
 [Globalize Webpack Plugin]: https://github.com/rxaviers/globalize-webpack-plugin


### PR DESCRIPTION
Fixes #2 .

Provides one new config option:
- `extractMessages`: create a new `messages/locale.json` file for every supported locale, on each compile.

Depends on #4 (just a refactor) and https://github.com/rxaviers/react-globalize-compiler/pull/2 (otherwise non-default locales get clobbered on every compile).
