### PR TITLE
add default messages to Globalize.messageFormatter

### DIFF
--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -72,7 +72,7 @@ ProductionModePlugin.prototype.apply = function(compiler) {
   var messages = attributes.messages;
   var writeMessages = attributes.writeMessages;
 
-  // Map eash AST and its request filepath.
+  // Map each AST and its request filepath.
   compiler.parser.plugin("program", function(ast) {
     extractor.asts[this.state.current.request] = ast;
   });

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var DefaultGlobalizeMessages = require("default-globalize-messages");
 var GlobalizePlugin = require("globalize-webpack-plugin");
 var ProductionModePlugin = require("./ProductionModePlugin");
 var SkipAMDOfUMDPlugin = require("skip-amd-webpack-plugin");
@@ -7,6 +8,8 @@ function ReactGlobalizePlugin(attributes) {
 }
 
 ReactGlobalizePlugin.prototype.apply = function(compiler) {
+  DefaultGlobalizeMessages.set();
+
   compiler.apply(
     // Plugin GlobalizePlugin.
     new GlobalizePlugin(this.attributes),

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/jquery-support/react-globalize-webpack-plugin",
   "dependencies": {
     "async": "^1.4.0",
+    "default-globalize-messages": "^0.1.1",
     "globalize-webpack-plugin": "0.1.x",
     "json-stable-stringify": "^1.0.0",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
I ran into some problems doing production builds on modules that use `Globalize.messageFormatter` with ICU messages as default messages (as opposed to English strings without any special characters).

The problem seems to be that react-globalize monkeypatches `Globalize.messageFormatter` here:
https://github.com/kborchers/react-globalize/blob/master/src/message.js#L157
but that code doesn't get executed by the webpack plugins or compilers, so the messages aren't found.

I get errors like:

```
 E_MISSING_MESSAGE: Missing required message content `{username}'s {count, plural, one {photo} other {photos}}`
```

Because the path has been sanitized to:

```
(username)'s (count, plural, one (photo) other (photos))
```

I've extracted the monkey-patching to a separate module here:
https://www.npmjs.com/package/default-globalize-messages

Pulling that in in the plugin avoids the error (there's another problem with the production builds I'm trying to isolate right now).
